### PR TITLE
Remove println calls from jenks and quantile

### DIFF
--- a/src/jenks.rs
+++ b/src/jenks.rs
@@ -105,7 +105,6 @@ pub fn get_jenks_breaks<T: ToPrimitive>(num_bins: usize, data: &[T]) -> Vec<f64>
     if permutations > 10000 {
         permutations = 10000
     }
-    println!("permutations: {}", permutations);
 
     let mut pseudo_rng = StdRng::seed_from_u64(123456789);
 
@@ -124,7 +123,6 @@ pub fn get_jenks_breaks<T: ToPrimitive>(num_bins: usize, data: &[T]) -> Vec<f64>
     for i in 0..best_breaks.len() {
         nat_breaks[i] = sorted_data[best_breaks[i]];
     }
-    println!("Breaks: {:#?}", nat_breaks);
 
     nat_breaks
 }

--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -78,7 +78,6 @@ pub fn get_quantile_breaks<T: ToPrimitive>(num_bins: usize, data: &[T]) -> Vec<f
         sorted_data.push(*item);
     }
     sorted_data.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    println!("{:#?}", sorted_data);
 
     let true_num_bins = std::cmp::min(num_vals, num_bins);
 


### PR DESCRIPTION
Thank you for providing this crate. 

I noticed a few `println` calls printing a significant amount of data while using the hinge and jenks implementations. This PR removes these calls, in case these are not intended to be removed, we should switch them to a logging crate like `tracing`.